### PR TITLE
Typo correction for clause_6_informative_text.adoc

### DIFF
--- a/standard/clause_6_informative_text.adoc
+++ b/standard/clause_6_informative_text.adoc
@@ -338,7 +338,7 @@ Alias URIs are interpreted from a reverse lookup from the file into the graph.  
 For an entity in an alias graph to be considered as an alias, the entity will define a RDF statement:
 
 ----
-  <$entity> <http://purl.org/dc/terms/identified> "$Literal" .
+  <$entity> <http://purl.org/dc/terms/identifier> "$Literal" .
 ----
 
 The Literal object of this RDF statement is the alias name.


### PR DESCRIPTION
Difference found between RDF statements in section 6.5.5 and requirement C-2.